### PR TITLE
Fixed extra schema substitution in the information_schema query

### DIFF
--- a/definitions/init.js
+++ b/definitions/init.js
@@ -200,9 +200,9 @@ function auth() {
 
 async function init() {
 
-	var is = await DB().check('information_schema.tables').where('table_schema', 'op').where('table_name', 'cl_config').promise();
+	var op_tables = await DB().query("SELECT FROM pg_tables WHERE schemaname = 'op' AND tablename = 'cl_config' LIMIT 1").promise();
 
-	if (is) {
+	if (op_tables.length) {
 		PAUSESERVER('Database');
 		reconfigure();
 		auth();


### PR DESCRIPTION
Faced the problem of launching the Open Platform when passing the schema to the connection string:

```?schema=public```

Reproduced in Postgres 14.6